### PR TITLE
task(EA1-499): Allow cookies

### DIFF
--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1582,7 +1582,7 @@ function (_React$Component) {
                   port: port,
                   path: path
                 }), {
-                  credentials: 'same-origin',
+                  credentials: 'include',
                   method: method,
                   body: JSON.stringify(body),
                   headers: this._headers

--- a/dist/index.js
+++ b/dist/index.js
@@ -1586,7 +1586,7 @@ function (_React$Component) {
                   port: port,
                   path: path
                 }), {
-                  credentials: 'same-origin',
+                  credentials: 'include',
                   method: method,
                   body: JSON.stringify(body),
                   headers: this._headers

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -82,7 +82,7 @@ class ActiveStorageProvider extends React.Component<Props> {
     }
 
     const response = await fetch(buildUrl({ protocol, host, port, path }), {
-      credentials: 'same-origin',
+      credentials: 'include',
       method,
       body: JSON.stringify(body),
       headers: this._headers,

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class ActiveStorageProvider extends React.Component<Props> {
     }
 
     const response = await fetch(buildUrl({ protocol, host, port, path }), {
-      credentials: 'same-origin',
+      credentials: 'include',
       method,
       body: JSON.stringify(body),
       headers: this._headers,


### PR DESCRIPTION
For the context:

credentials: "same-origin" vs credentials: "include" (Fetch API):

- same-origin — Sends cookies/auth headers only when the request URL is on the same origin (same scheme + host + port) as the calling page. This is the default.
- include — Sends cookies/auth headers on every request, including cross-origin ones (e.g., app.example.com → api.example.com).

When to use include: When your frontend and API are on different origins and you need cookies